### PR TITLE
Feature/86 게임 관전 페이지를 바탕으로 게임 전적 페이지 구현(하나의 페이지 공유)

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -64,10 +64,10 @@ function Router() {
           }
         />
         <Route
-          path="/game/record/:userId"
+          path="/game/record/:userId/history"
           element={
             <CheckLogin>
-              <GameRecord />
+              <GamePage title="Game Record" />
             </CheckLogin>
           }
         />

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,7 +5,6 @@ import Channel from './components/pages/chat/channel-page/Channel';
 import MyMsg from './components/pages/chat/mymsg-page/MyMsg';
 import FriendList from './components/pages/friend/friendlist-page/FriendList';
 import BannedList from './components/pages/friend/bannedlist-page/BannedList';
-import GameRecord from './components/pages/game/gamerecord-page/GameRecord';
 import GameShop from './components/pages/game/gameshop-page/GameShop';
 import PlayGame from './components/pages/game/playgame-page/PlayGame';
 import FriendProfile from './components/pages/profiles/friend-page/FriendProfile';

--- a/src/api/Friends.ts
+++ b/src/api/Friends.ts
@@ -1,7 +1,8 @@
-import { useQuery } from 'react-query';
+import { UseQueryOptions, useQuery } from 'react-query';
 import { AxiosError, AxiosResponse } from 'axios';
 import { useAxiosWithToken } from '.';
 import { IFriend } from '../components/pages/friend/friendlist-page';
+import { IGameHistoryByAPI } from '../components/pages/game/watchgame-page';
 
 export const useGetFriendList = () => {
   const axiosInstance = useAxiosWithToken();
@@ -12,4 +13,29 @@ export const useGetFriendList = () => {
     );
     return response.data;
   });
+};
+
+export const useGetGameHistory = (
+  userId: string | undefined,
+  gameName: string | null,
+  onError: (error: AxiosError) => void,
+  isEnabled: boolean,
+) => {
+  const axiosInstance = useAxiosWithToken();
+
+  const queryOptions: UseQueryOptions<IGameHistoryByAPI, AxiosError> = {
+    queryFn: async () => {
+      const response: AxiosResponse<IGameHistoryByAPI> =
+        await axiosInstance.get(`/friends/${userId}/history?game=${gameName}`);
+      return response.data;
+    },
+    onError: error => onError(error),
+    retry: 0, // 바로 실패로 처리하려면 시도 횟수를 0으로 설정
+    enabled: isEnabled,
+  };
+
+  return useQuery<IGameHistoryByAPI, AxiosError>(
+    ['GameHistory', gameName, userId],
+    queryOptions,
+  );
 };

--- a/src/api/Game.ts
+++ b/src/api/Game.ts
@@ -20,7 +20,7 @@ export const useGetGameWatchList = (
     retry: 0, // 바로 실패로 처리하려면 시도 횟수를 0으로 설정
   };
 
-  return useQuery<IGameWatch, AxiosError>('GameWatchList', queryOptions);
+  return useQuery<IGameWatch, AxiosError>(['gameWatch', gameId], queryOptions);
 };
 
 export const useGetGameList = () => {

--- a/src/api/Game.ts
+++ b/src/api/Game.ts
@@ -5,7 +5,8 @@ import { IGameInfo, IGameWatch } from '../components/pages/game/watchgame-page';
 
 export const useGetGameWatchList = (
   gameId: string | undefined,
-  onError: () => void,
+  onError: (error: AxiosError) => void,
+  isEnabled: boolean,
 ) => {
   const axiosInstance = useAxiosWithToken();
 
@@ -16,8 +17,9 @@ export const useGetGameWatchList = (
       );
       return response.data;
     },
-    onError: () => onError(),
+    onError: error => onError(error),
     retry: 0, // 바로 실패로 처리하려면 시도 횟수를 0으로 설정
+    enabled: isEnabled, // 여기에 enabled 속성을 추가합니다.
   };
 
   return useQuery<IGameWatch, AxiosError>(['gameWatch', gameId], queryOptions);

--- a/src/components/pages/game/gamerecord-page/GameRecord.tsx
+++ b/src/components/pages/game/gamerecord-page/GameRecord.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function GameRecord() {
-  return <div>gamerecord</div>;
-}

--- a/src/components/pages/game/watchgame-page/GamePage.tsx
+++ b/src/components/pages/game/watchgame-page/GamePage.tsx
@@ -141,6 +141,7 @@ export default function GamePage({ title }: Prop) {
                   user1Image={data.user1Image}
                   user2Image={data.user2Image}
                   currentViewer={data.currentViewer}
+                  selectedGame={selectedGame}
                 />
               );
             })}

--- a/src/components/pages/game/watchgame-page/GamePage.tsx
+++ b/src/components/pages/game/watchgame-page/GamePage.tsx
@@ -132,12 +132,10 @@ export default function GamePage({ title }: Prop) {
   };
 
   /* UseEffect */
-  // 게임와치 페이지인지 게임 전적 페이지 상태인지 구분(페이지별 리액트 쿼리 선택적으로 호출)
-
+  // 에러모달 설정과 새로고침 시 URL의 선택한 Select Game 유지
   useEffect(() => {
     setIsErrorGet(false);
 
-    // 새로고침 시 URL의 선택한 Select Game 유지
     if (title === 'Game Watch' && gameId) {
       const getKeyByValue = (map: Map<string, string>, value: string) => {
         const entryFound = Array.from(map.entries()).find(

--- a/src/components/pages/game/watchgame-page/GamePage.tsx
+++ b/src/components/pages/game/watchgame-page/GamePage.tsx
@@ -1,16 +1,26 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { useNavigate, useParams } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { AxiosError } from 'axios';
 import GameSelect from './component/GameSelect';
 import Layout from '../../../commons/layout/Layout';
 import Header from '../../../commons/header/Header';
 import Footer from '../../../commons/footer/Footer';
 import GameHistory from './component/GameHistory';
 import { useGetGameList, useGetGameWatchList } from '../../../../api/Game';
-import { IGameHistory, IGameInfo, IMatch } from '.';
+import {
+  ICurrentGameHistory,
+  IGameHistroy,
+  IGameInfo,
+  IMatch,
+  IOldGameHistory,
+} from '.';
 import { getImageUrl } from '../../../../api/ProfileImge';
 import { userState } from '../../../../recoil/locals/login/atoms/atom';
+import { useGetGameHistory } from '../../../../api/Friends';
+import { isErrorOnGet } from '../../../../recoil/globals/atoms/atom';
+import ErrorPopup from '../../../commons/error/ErrorPopup';
 
 const Container = styled.div`
   display: flex;
@@ -39,46 +49,118 @@ interface Prop {
 }
 
 export default function GamePage({ title }: Prop) {
+  /* 공용 상태 */
+  // 게임 와치 페이지와 게임 전적 페이지 구별하는 용도
+  const isGameWatchPage = title === 'Game Watch';
+  const { gameId, userId } = useParams<{
+    gameId: string;
+    userId: string;
+  }>();
   const userInfo = useRecoilValue(userState);
-  const { gameId } = useParams<{ gameId: string }>();
   const navigate = useNavigate();
   const [gameName, setGameName] = useState<string>('');
   const [selectedGame, setSelectedGame] = useState<string>(gameName);
-  const [gameHistoryData, setGameHistoryData] = useState<IGameHistory[]>();
+  const handleError = (error: AxiosError) => {
+    if (error.response?.status === 409) {
+      // NotFound 에러에 대한 처리 (모달 띄우기)
+      setIsErrorGet(true);
+    } else {
+      // navigate('/404');
+    }
+  };
   const [gameIdMapping, setGameIdMapping] = useState<Map<string, string>>(
     new Map(),
   );
+  const [isErrorGet, setIsErrorGet] = useRecoilState(isErrorOnGet);
   const { data: gameInfos } = useGetGameList();
-  const handleError = () => {
-    navigate('/404');
+  const getBackPath = () => {
+    if (isGameWatchPage) {
+      return '/game/shop';
+    }
+    if (userInfo.userId === userId) {
+      return '/profile/my/:id';
+    }
+    return `/profile/friend/${userId}`;
   };
+  const backPath = getBackPath();
+
+  /* 게임 와치 페이지 상태 */
+  const [gameCurrentHistoryData, setGameCurrentHistoryData] =
+    useState<ICurrentGameHistory[]>();
   const {
     data: gameWatchData,
     isLoading,
     isError,
-  } = useGetGameWatchList(gameId, handleError);
+  } = useGetGameWatchList(gameId, handleError, isGameWatchPage);
 
-  useEffect(() => {
-    if (gameInfos) {
-      const createGameIdMapping = async () => {
-        const newGameIdMapping = new Map();
-
-        gameInfos.forEach((game: IGameInfo) => {
-          newGameIdMapping.set(game.name, game.gameId);
-        });
-
-        setGameIdMapping(newGameIdMapping);
-      };
-
-      createGameIdMapping();
+  // 다른 게임 페이지 상태로 변경: Select 박스에 전달하여 다른 value 선택 시
+  const handleGameWatchChange = async (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    setSelectedGame(event.target.value);
+    const newGameId = gameIdMapping.get(event.target.value);
+    if (newGameId) {
+      // gameId가 변경되면 해당 gameId로 페이지를 이동합니다.
+      navigate(`/game/watch/${newGameId}`);
     }
-  }, [gameInfos]);
+  };
+
+  /* 게임 전적 페이지 상태 */
+  const [gameOldHistoryData, setGameOldHistoryData] =
+    useState<IOldGameHistory[]>();
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const gameNameByQurey = queryParams.get('game');
+  const { data: gameHistory } = useGetGameHistory(
+    userId,
+    gameNameByQurey,
+    handleError,
+    !isGameWatchPage,
+  );
+
+  // 다른 게임 페이지 상태로 변경: Select 박스에 전달하여 다른 value 선택 시
+  const handleGameHistoryChange = async (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    setSelectedGame(event.target.value);
+    const newGameId = gameIdMapping.get(event.target.value);
+
+    if (newGameId) {
+      // gameId가 변경되면 해당 gameId로 페이지를 이동합니다.
+      navigate(`/game/record/${userId}/history?game=${event.target.value}`);
+    }
+  };
+
+  /* UseEffect */
+  // 게임와치 페이지인지 게임 전적 페이지 상태인지 구분(페이지별 리액트 쿼리 선택적으로 호출)
 
   useEffect(() => {
-    if (gameWatchData) {
-      setGameName(gameWatchData.gameName);
+    setIsErrorGet(false);
+
+    // 새로고침 시 URL의 선택한 Select Game 유지
+    if (title === 'Game Watch' && gameId) {
+      const getKeyByValue = (map: Map<string, string>, value: string) => {
+        const entryFound = Array.from(map.entries()).find(
+          ([key, val]) => val === value,
+        );
+        return entryFound ? entryFound[0] : null;
+      };
+      const keyFound = getKeyByValue(gameIdMapping, gameId);
+
+      if (keyFound) {
+        setSelectedGame(keyFound);
+      }
+    } else if (gameNameByQurey) {
+      setSelectedGame(gameNameByQurey);
+    }
+  }, [selectedGame]);
+
+  // 리액트 쿼리에서 가져온 데이터들을 상태로 업데이트
+  useEffect(() => {
+    if (gameId && gameWatchData) {
+      setGameName(gameWatchData.name);
       const updateGameHistoryData = async () => {
-        const newGameHistory: IGameHistory[] = await Promise.all(
+        const newGameHistory: ICurrentGameHistory[] = await Promise.all(
           gameWatchData.matches.map(async (data: IMatch) => {
             const imageUrlOfUser1 = await getImageUrl(
               data.user1.userId,
@@ -98,26 +180,59 @@ export default function GamePage({ title }: Prop) {
             };
           }),
         );
-        setGameHistoryData(newGameHistory);
+        setGameCurrentHistoryData(newGameHistory);
+      };
+      updateGameHistoryData();
+    } else if (gameHistory) {
+      setGameName(gameHistory.gameName);
+      const updateGameHistoryData = async () => {
+        const newGameHistory: IOldGameHistory[] = await Promise.all(
+          gameHistory.gameHistory.map(async (data: IGameHistroy) => {
+            const imageUrlOfWinner = await getImageUrl(
+              data.winner.userId,
+              userInfo.token,
+            );
+            const imageUrlOfLoser = await getImageUrl(
+              data.loser.userId,
+              userInfo.token,
+            );
+            return {
+              winner: data.winner.nickname,
+              winnerImage: imageUrlOfWinner,
+              winnerScore: data.winner.score,
+              loser: data.loser.nickname,
+              loserImage: imageUrlOfLoser,
+              loserScore: data.loser.score,
+              gameHistoyId: data.id,
+            };
+          }),
+        );
+        setGameOldHistoryData(newGameHistory);
       };
       updateGameHistoryData();
     }
-  }, [gameWatchData]);
+  }, [gameWatchData, gameHistory]);
 
-  const handleGameChange = async (
-    event: React.ChangeEvent<HTMLSelectElement>,
-  ) => {
-    setSelectedGame(event.target.value);
-    const newGameId = gameIdMapping.get(event.target.value);
-    if (newGameId) {
-      // gameId가 변경되면 해당 gameId로 페이지를 이동합니다.
-      navigate(`/game/watch/${newGameId}`);
+  // 게임이름과 게임ID를 맵핑하기 위해서 리액트 쿼리로 상태 업데이트하는 로직
+  useEffect(() => {
+    if (gameInfos) {
+      const createGameIdMapping = async () => {
+        const newGameIdMapping = new Map();
+
+        gameInfos.forEach((game: IGameInfo) => {
+          newGameIdMapping.set(game.name, game.gameId);
+        });
+
+        setGameIdMapping(newGameIdMapping);
+      };
+
+      createGameIdMapping();
     }
-  };
+  }, [gameInfos]);
 
   return (
     <Layout
-      Header={<Header title={title} backPath="/game/shop" />}
+      Header={<Header title={title} backPath={backPath} />}
       Footer={<Footer tab="Game" />}
     >
       <Container>
@@ -126,26 +241,46 @@ export default function GamePage({ title }: Prop) {
             gameName={gameName}
             selectedGame={selectedGame}
             setSelectedGame={setSelectedGame}
-            handleGameChange={handleGameChange}
+            handleGameChange={
+              isGameWatchPage ? handleGameWatchChange : handleGameHistoryChange
+            }
           />
         </GameSelectWrapper>
-        <GameHistorytWrapper>
-          {gameHistoryData &&
-            gameHistoryData?.map((data: IGameHistory) => {
-              return (
-                <GameHistory
-                  key={data.matchId}
-                  matchId={data.matchId}
-                  user1={data.user1}
-                  user2={data.user2}
-                  user1Image={data.user1Image}
-                  user2Image={data.user2Image}
-                  currentViewer={data.currentViewer}
-                  selectedGame={selectedGame}
-                />
-              );
-            })}
-        </GameHistorytWrapper>
+
+        {isErrorGet ? (
+          <ErrorPopup message="[게임 조회 실패] 해당하는 게임을 구매하지 않거나 조회에 실패했습니다 " />
+        ) : (
+          <GameHistorytWrapper>
+            {isGameWatchPage
+              ? gameCurrentHistoryData?.map((data: ICurrentGameHistory) => {
+                  return (
+                    <GameHistory
+                      key={data.matchId}
+                      matchId={data.matchId}
+                      user1={data.user1}
+                      user2={data.user2}
+                      user1Image={data.user1Image}
+                      user2Image={data.user2Image}
+                      currentViewer={data.currentViewer}
+                      selectedGame={selectedGame}
+                    />
+                  );
+                })
+              : gameOldHistoryData?.map((data: IOldGameHistory) => {
+                  return (
+                    <GameHistory
+                      key={data.gameHistoyId}
+                      user1={data.winner}
+                      user2={data.loser}
+                      user1Image={data.winnerImage}
+                      user2Image={data.loserImage}
+                      winnerScore={data.winnerScore}
+                      loserScore={data.loserScore}
+                    />
+                  );
+                })}
+          </GameHistorytWrapper>
+        )}
       </Container>
     </Layout>
   );

--- a/src/components/pages/game/watchgame-page/GamePage.tsx
+++ b/src/components/pages/game/watchgame-page/GamePage.tsx
@@ -117,7 +117,7 @@ export default function GamePage({ title }: Prop) {
 
   return (
     <Layout
-      Header={<Header title={title} friendToggle toggleMove />}
+      Header={<Header title={title} backPath="/game/shop" />}
       Footer={<Footer tab="Game" />}
     >
       <Container>

--- a/src/components/pages/game/watchgame-page/component/GameHistory.tsx
+++ b/src/components/pages/game/watchgame-page/component/GameHistory.tsx
@@ -60,13 +60,15 @@ const Result = styled.span<{ Full: string }>`
 `;
 
 interface Prop {
-  matchId: string;
+  matchId?: string;
   user1: string;
   user1Image: string;
   user2: string;
   user2Image: string;
-  currentViewer: number;
-  selectedGame: string;
+  currentViewer?: number;
+  selectedGame?: string;
+  winnerScore?: number;
+  loserScore?: number;
 }
 
 export default function GameHistory({
@@ -77,11 +79,13 @@ export default function GameHistory({
   user2Image,
   currentViewer,
   selectedGame,
+  winnerScore,
+  loserScore,
 }: Prop) {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    if (selectedGame === '핑퐁핑퐁' && currentViewer < 10) {
+    if (selectedGame === '핑퐁핑퐁' && currentViewer && currentViewer < 10) {
       navigate(`/game/play/${matchId}`);
     }
   };
@@ -94,9 +98,18 @@ export default function GameHistory({
       </ProfileWrapper>
       <ContentWrapper>
         <Versus>VS</Versus>
-        <Result Full={currentViewer >= 10 ? 'true' : 'false'}>
-          {currentViewer}/10
-        </Result>
+        {currentViewer && (
+          <Result
+            Full={currentViewer && currentViewer >= 10 ? 'true' : 'false'}
+          >
+            {currentViewer}/10
+          </Result>
+        )}
+        {winnerScore && (
+          <Result Full="false">
+            {winnerScore}/{loserScore}
+          </Result>
+        )}
       </ContentWrapper>
       <ProfileWrapper>
         <ProfileImage src={user2Image} alt={`${user2}의 이미지`} />

--- a/src/components/pages/game/watchgame-page/component/GameHistory.tsx
+++ b/src/components/pages/game/watchgame-page/component/GameHistory.tsx
@@ -50,10 +50,10 @@ const Versus = styled.span`
 `;
 
 // 10명이 될 때 색깔 바꾸기
-const Result = styled.span<{ Win: string }>`
+const Result = styled.span<{ Full: string }>`
   font-size: 3rem;
   font-weight: ${defaultTheme.fontWeight.weightExtraBold};
-  color: ${props => (props.Win ? '#0AD065' : '#F48080')};
+  color: ${props => (props.Full === 'false' ? '#0AD065' : '#F48080')};
   text-shadow: -1px -1px 0 rgba(0, 0, 0, 0.2), 1px -1px 0 rgba(0, 0, 0, 0.2),
     -1px 1px 0 rgba(0, 0, 0, 0.2), 1px 1px 0 rgba(0, 0, 0, 0.2);
   margin-top: 2.3rem;
@@ -81,7 +81,7 @@ export default function GameHistory({
   const navigate = useNavigate();
 
   const handleClick = () => {
-    if (selectedGame === '핑퐁핑퐁') {
+    if (selectedGame === '핑퐁핑퐁' && currentViewer < 10) {
       navigate(`/game/play/${matchId}`);
     }
   };
@@ -94,7 +94,9 @@ export default function GameHistory({
       </ProfileWrapper>
       <ContentWrapper>
         <Versus>VS</Versus>
-        <Result Win="Win">{currentViewer}/10</Result>
+        <Result Full={currentViewer >= 10 ? 'true' : 'false'}>
+          {currentViewer}/10
+        </Result>
       </ContentWrapper>
       <ProfileWrapper>
         <ProfileImage src={user2Image} alt={`${user2}의 이미지`} />

--- a/src/components/pages/game/watchgame-page/component/GameHistory.tsx
+++ b/src/components/pages/game/watchgame-page/component/GameHistory.tsx
@@ -66,6 +66,7 @@ interface Prop {
   user2: string;
   user2Image: string;
   currentViewer: number;
+  selectedGame: string;
 }
 
 export default function GameHistory({
@@ -75,11 +76,14 @@ export default function GameHistory({
   user2,
   user2Image,
   currentViewer,
+  selectedGame,
 }: Prop) {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(`/game/play/${matchId}`);
+    if (selectedGame === '핑퐁핑퐁') {
+      navigate(`/game/play/${matchId}`);
+    }
   };
 
   return (

--- a/src/components/pages/game/watchgame-page/component/GameSelect.tsx
+++ b/src/components/pages/game/watchgame-page/component/GameSelect.tsx
@@ -23,11 +23,6 @@ export default function GameSelect({
 
   const selectRef = useRef<HTMLSelectElement>(null);
 
-  // // 선택된 게임 -> 초기 게임 핑퐁핑퐁(0)
-  // const handleGameChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-  //   setSelectedGame(event.target.value);
-  // };
-
   useEffect(() => {
     setSelectedGame(gameName);
   }, [gameName]);

--- a/src/components/pages/game/watchgame-page/index.ts
+++ b/src/components/pages/game/watchgame-page/index.ts
@@ -4,6 +4,13 @@ interface IUser {
   image: string;
 }
 
+interface IUserFromGame {
+  userId: string;
+  nickname: string;
+  image: string;
+  score: number;
+}
+
 export interface IMatch {
   user1: IUser;
   user2: IUser;
@@ -11,13 +18,25 @@ export interface IMatch {
   gameWatchId: string;
 }
 
-export interface IGameWatch {
+export interface IGameHistroy {
+  id: string;
+  winner: IUserFromGame;
+  loser: IUserFromGame;
+}
+
+export interface IGameHistoryByAPI {
   gameId: string;
   gameName: string;
+  gameHistory: IGameHistroy[];
+}
+
+export interface IGameWatch {
+  gameId: string;
+  name: string;
   matches: IMatch[];
 }
 
-export interface IGameHistory {
+export interface ICurrentGameHistory {
   user1: string;
   user1Image: string;
   user2: string;
@@ -32,4 +51,14 @@ export interface IGameInfo {
   price: number;
   isPlayable: boolean;
   isBuy: boolean;
+}
+
+export interface IOldGameHistory {
+  winner: string;
+  winnerImage: string;
+  winnerScore: number;
+  loser: string;
+  loserImage: string;
+  loserScore: number;
+  gameHistoyId: string;
 }

--- a/src/components/pages/profiles/friend-page/FriendProfile.tsx
+++ b/src/components/pages/profiles/friend-page/FriendProfile.tsx
@@ -188,9 +188,7 @@ export default function FriendProfile() {
           <HistoryText>{getUserGameHistoryText(selectedGame)}</HistoryText>
           <GameButton
             onClick={() =>
-              navigate(
-                `/game/record/${userInfo.userId}/history?game=${selectedGame}`,
-              )
+              navigate(`/game/record/${buddyId}/history?game=${selectedGame}`)
             }
           >
             전적 보기

--- a/src/components/pages/profiles/friend-page/FriendProfile.tsx
+++ b/src/components/pages/profiles/friend-page/FriendProfile.tsx
@@ -186,7 +186,13 @@ export default function FriendProfile() {
         </SelectGameContainer>
         <GameContainer>
           <HistoryText>{getUserGameHistoryText(selectedGame)}</HistoryText>
-          <GameButton onClick={() => navigate('/game/record')}>
+          <GameButton
+            onClick={() =>
+              navigate(
+                `/game/record/${userInfo.userId}/history?game=${selectedGame}`,
+              )
+            }
+          >
             전적 보기
           </GameButton>
           <GameButton

--- a/src/components/pages/profiles/my-page/MyProfile.tsx
+++ b/src/components/pages/profiles/my-page/MyProfile.tsx
@@ -75,6 +75,11 @@ export default function MyProfile() {
     setSelectedGameId(event.target.value);
   };
 
+  // 게임 ID로 게임 이름을 가져오는 맵
+  const [gameIdMapping, setGameIdMapping] = useState<Map<string, string>>(
+    new Map(),
+  );
+
   const selectRef = useRef<HTMLSelectElement>(null);
   const socketRef = useSocket();
 
@@ -94,6 +99,11 @@ export default function MyProfile() {
     setShowReadyGameModal(!showReadyGameModal);
   };
 
+  const getGameNameById = (gameId: string) => {
+    const gameName = gameIdMapping.get(gameId);
+    return gameName;
+  };
+
   useEffect(() => {
     const fetchData = async () => {
       const data = await axios.get(`http://localhost:3000/account`, {
@@ -101,6 +111,18 @@ export default function MyProfile() {
       });
       setUser(data.data.user);
       setUserGames(data.data.userGame);
+
+      const createGameIdMapping = async () => {
+        const newGameIdMapping = new Map();
+
+        data.data.userGame.forEach((game: UserGame) => {
+          newGameIdMapping.set(game.game.gameId, game.game.name);
+        });
+
+        setGameIdMapping(newGameIdMapping);
+      };
+
+      createGameIdMapping();
     };
     fetchData();
   }, []);
@@ -185,7 +207,17 @@ export default function MyProfile() {
         </SelectGameContainer>
         <GameContainer>
           <HistoryText>{getUserGameHistoryText(selectedGameId)}</HistoryText>
-          <GameButton onClick={() => navigate('/game/record')}>
+          <GameButton
+            onClick={() => {
+              let gameName = getGameNameById(selectedGameId);
+              if (!selectedGameId) {
+                gameName = '핑퐁핑퐁';
+              }
+              navigate(
+                `/game/record/${userInfo.userId}/history?game=${gameName}`,
+              );
+            }}
+          >
             전적 보기
           </GameButton>
           <GameButton


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

<!--
하나씩 확인 후 체크박스에 표시해주세요.
-->

- [x] PR 제목: [Feature/Fix/Refactor...] 작업 내용 한 줄 요약 (브랜치 이름) #이슈번호
- [x] commit message 가 적절한지 확인해주세요.
- [x] 적절한 branch 로 요청했는지 확인해주세요.
- [x] Assignees, Label 을 붙여주세요.
- [x] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer 로 등록해주세요.
- [x] PR이 승인된 경우 해당 브랜치는 삭제해 주세요!

<br/>

## 🔄 변경 사항 

<!-- 해당 pr에서 작업한 내역을 적어주세요. 처음엔 간단하게 요약, list 형식으로 세부사항 작성 -->

게임 관전 페이지에 게임 전적페이지도 추가

게임 관전이나 게임 전적 페이지에서 Select박스에서 새로고침하더라도 그대로 Select 유지되게 수정

게임 전적 페이지에서 구매하지 않은 게임에 대해서 에러 모달 설정

게임 관전 페이지와 게임 전적페이지의 헤더의 뒤로 버튼 설정


<br/>

<!-- 관련되어있는 Issue Number 를 작성하세요! 해당 이슈를 이곳에 적으면 pr merge 이후 해당 이슈는 자동으로 close 됩니다. -->

closes: #86 

## 👨🏻‍💻 테스트 체크리스트

<!-- 테스트 사항이 있다면 작성해 주세요! -->

프론트 개발하면서 직접 누르면서 테스트

<br/>

## 📌 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 있다면 적어주세요.
주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 리뷰어로 등록해주세요. (다른 사람이 작성한 코드 수정 등)
코드 리뷰 시 더 꼼꼼하게 확인 받고 싶은 부분이 있다면 적어주세요.
-->

<br/>
